### PR TITLE
Fix header background on IE8

### DIFF
--- a/templates/joomla/css/custom.css
+++ b/templates/joomla/css/custom.css
@@ -42,7 +42,6 @@ box-shadow:0 5px 15px -10px rgba(0, 0, 0, 1);
   background-image: url("../../../images/homepage/header.jpg");
   background-repeat: no-repeat;
   background-position: center 70%;
-  background-attachment: scroll;
   background-size: cover;
   background-color: #25304f;
 }

--- a/templates/joomla/css/custom.css
+++ b/templates/joomla/css/custom.css
@@ -39,7 +39,12 @@ box-shadow:0 5px 15px -10px rgba(0, 0, 0, 1);
 /*hero*/
 .moduletable.topbanner {
   margin: -10px 0 0;
-  background: #25304f url("../../../images/homepage/header.jpg") no-repeat scroll center 70% / cover ;
+  background-image: url("../../../images/homepage/header.jpg");
+  background-repeat: no-repeat;
+  background-position: center 70%;
+  background-attachment: scroll;
+  background-size: cover;
+  background-color: #25304f;
 }
 .topbanner .container {
   padding-bottom: 50px;


### PR DESCRIPTION
In IE8, the header background isn't being displayed. This is because `background: cover` isn't supported. If it's part of the background chain, then it won't show, however if the background properties are separated, it will still be displayed.